### PR TITLE
Get the url variable from terraform.tfvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple program that will build the infrastructure to ping a website.
 
 ## Configuring the Site
 
-Change `url := "http://example.com/"` to `url := "<desired-site>"` in `function/function.go`.
+Change `url = "http://example.com/"` to `url = "<desired-site>"` in `terraform.tfvars`.
 
 ## Building the Zip
 

--- a/function/function.go
+++ b/function/function.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"fmt"
 	"net/http"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func ping() (string, error) {
-	url := "http://example.com/"
+	url := os.Getenv("URL")
 	resp, err := http.Get(url)
 	return fmt.Sprintf("%s returned %s", url, resp.Status), err
 }

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,16 @@
 provider "aws" {
-    region = "us-east-1"
+  region = "us-east-1"
+}
+
+variable "url" {
+  type        = "string"
+  description = "URL of website to ping"
+  default     = "http://example.com"
 }
 
 resource "aws_iam_role" "lambda_exec_role" {
   name = "lambda_exec_role"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -22,10 +29,16 @@ EOF
 }
 
 resource "aws_lambda_function" "demo_lambda" {
-    function_name = "demo_lambda"
-    handler = "main"
-    runtime = "go1.x"
-    filename = "./function/function.zip"
-    source_code_hash = "${base64sha256(file("./function/function.zip"))}"
-    role = "${aws_iam_role.lambda_exec_role.arn}"
+  function_name    = "demo_lambda"
+  handler          = "main"
+  runtime          = "go1.x"
+  filename         = "./function/function.zip"
+  source_code_hash = "${base64sha256(file("./function/function.zip"))}"
+  role             = "${aws_iam_role.lambda_exec_role.arn}"
+
+  environment {
+    variables = {
+      URL = "${var.url}"
+    }
+  }
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,1 @@
+url = "http://example.com"


### PR DESCRIPTION
Just for the lulz, this makes it so
1.  the url that the function is checking is set in `terraform.tfvars`
2. The `url` variable is passed into the terraform lambda resource as the env var `URL`
3. The lambda function looks for the env var `URL`